### PR TITLE
Release for v0.0.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,8 +1,51 @@
-# configuration file for https://github.com/Songmu/tagpr
-tagpr:
-  release:
-    key: version
-    file: go.mod
-  changelog:
-    path: CHANGELOG.md
-  commit_message_prefix: ""
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The tagpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release and versioning.
+#
+#   tagpr.postVersionCommand (Optional)
+#       Command to change files just after versioning.
+#
+#   tagpr.template (Optional)
+#       Pull request template file in go template format
+#
+#   tagpr.templateText (Optional)
+#       Pull request template text in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+#
+#   tagpr.majorLabels (Optional)
+#       Label of major update targets. Default is [major]
+#
+#   tagpr.minorLabels (Optional)
+#       Label of minor update targets. Default is [minor]
+#
+#   tagpr.commitPrefix (Optional)
+#       Prefix of commit message. Default is "[tagpr]"
+#
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [v0.0.1](https://github.com/orangekame3/qasmfmt/commits/v0.0.1) - 2025-06-28
+- Implement OpenQASM 3.0 Formatter with CLI and Tests by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/1
+- Add formatting checks and EditorConfig compliance to CI workflows by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/2
+- Fix .editorconfig for Makefile and add Taskfile support by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/3
+- Refactor tagpr.yml configuration by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/4


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* Implement OpenQASM 3.0 Formatter with CLI and Tests by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/1
* Add formatting checks and EditorConfig compliance to CI workflows by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/2
* Fix .editorconfig for Makefile and add Taskfile support by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/3
* Refactor tagpr.yml configuration by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/4

## New Contributors
* @orangekame3 made their first contribution in https://github.com/orangekame3/qasmfmt/pull/1

**Full Changelog**: https://github.com/orangekame3/qasmfmt/commits/v0.0.1