### PR TITLE
Fix releaser by adding TAP_GITHUB_TOKEN environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Add the TAP_GITHUB_TOKEN to the releaser job environment to ensure proper authentication during the release process.