### PR TITLE
Release for v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.0.4](https://github.com/orangekame3/qasmfmt/compare/v0.0.3...v0.0.4) - 2025-06-28
+- Update versioning and build information by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/10
+- Remove unnecessary whitespace in Taskfile.yaml and main.go by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/12
+- Feature/remove unnecessary dependencies by @itsubaki in https://github.com/orangekame3/qasmfmt/pull/13
+- Enhance functionality and performance of qasmfmt by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/14
+- Clean up format workflow and remove unused files by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/15
+- Update demo tasks to use test data files by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/16
+- Improve formatting and structure of PARSER_ISSUES.md for clarity by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/17
+
 ## [v0.0.3](https://github.com/orangekame3/qasmfmt/compare/v0.0.2...v0.0.3) - 2025-06-28
 - Update GITHUB_TOKEN in release workflow by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/8
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "0.0.3"
+	Version   = "0.0.4"
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
This pull request is for the next release as v0.0.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Update versioning and build information by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/10
* Remove unnecessary whitespace in Taskfile.yaml and main.go by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/12
* Feature/remove unnecessary dependencies by @itsubaki in https://github.com/orangekame3/qasmfmt/pull/13
* Enhance functionality and performance of qasmfmt by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/14
* Clean up format workflow and remove unused files by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/15
* Update demo tasks to use test data files by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/16
* Improve formatting and structure of PARSER_ISSUES.md for clarity by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/17

## New Contributors
* @itsubaki made their first contribution in https://github.com/orangekame3/qasmfmt/pull/13

**Full Changelog**: https://github.com/orangekame3/qasmfmt/compare/v0.0.3...v0.0.4