### PR TITLE
Remove unnecessary whitespace in Taskfile.yaml and main.go

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -199,10 +199,10 @@ tasks:
         cat > examples/bell_state.qasm << 'EOF'
         OPENQASM 3.0;
         include "stdgates.qasm";
-        
+
         qubit[2] q;
         bit[2] c;
-        
+
         h q[0];
         cx q[0], q[1];
         measure q -> c;
@@ -211,19 +211,19 @@ tasks:
         cat > examples/grover.qasm << 'EOF'
         OPENQASM 3.0;
         include "stdgates.qasm";
-        
+
         qubit[3] q;
         bit[3] c;
-        
+
         // Initialize superposition
         h q[0];
         h q[1];
         h q[2];
-        
+
         // Oracle
         cz q[0], q[2];
         cz q[1], q[2];
-        
+
         // Diffuser
         h q[0];
         h q[1];
@@ -238,7 +238,7 @@ tasks:
         h q[0];
         h q[1];
         h q[2];
-        
+
         measure q -> c;
         EOF
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "qasmfmt [file...]",
@@ -25,11 +24,9 @@ Examples:
   qasmfmt -c example.qasm            # Check if file is formatted
   qasmfmt -i 4 example.qasm          # Use 4 spaces for indentation
   qasmfmt *.qasm                     # Format multiple files`,
-		Args:    cobra.MinimumNArgs(1),
-		RunE:    cmd.RunRootFormat,
+		Args: cobra.MinimumNArgs(1),
+		RunE: cmd.RunRootFormat,
 	}
-
-	
 
 	// Global flags
 	rootCmd.PersistentFlags().BoolP("write", "w", false, "write result to (source) file instead of stdout")
@@ -49,4 +46,3 @@ Examples:
 		os.Exit(1)
 	}
 }
-


### PR DESCRIPTION
Clean up formatting by removing unnecessary whitespace in Taskfile.yaml and main.go files.