### PR TITLE
Release for v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.6](https://github.com/orangekame3/qasmfmt/compare/v0.0.5...v0.0.6) - 2025-06-28
+- Update demo GIF to reflect recent changes by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/22
+- Update license from MIT to Apache 2.0 by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/24
+
 ## [v0.0.5](https://github.com/orangekame3/qasmfmt/compare/v0.0.4...v0.0.5) - 2025-06-28
 - Enhance README.md with clarification on formatting multiple files by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/18
 - Enhance formatting command for stdin support and error handling by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/20

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "0.0.5"
+	Version   = "0.0.6"
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
This pull request is for the next release as v0.0.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Update demo GIF to reflect recent changes by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/22
* Update license from MIT to Apache 2.0 by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/24


**Full Changelog**: https://github.com/orangekame3/qasmfmt/compare/v0.0.5...v0.0.6