### PR TITLE
Add CI/CD integration and update license

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,6 @@ brews:
       name: homebrew-tap
     homepage: "https://github.com/orangekame3/qasmfmt"
     description: "A formatter for OpenQASM 3 files"
-    license: "MIT"
+    license: "Apache-2.0"
     test: |
       system "#{bin}/qasmfmt", "--version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o qasmfmt .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+
+COPY --from=builder /app/qasmfmt .
+
+ENTRYPOINT ["./qasmfmt"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ task install
 go install github.com/orangekame3/qasmfmt@latest
 ```
 
+### Using Docker
+
+```bash
+# Pull the image
+docker pull ghcr.io/orangekame3/qasmfmt:latest
+
+# Format a file
+docker run --rm -v $(pwd):/workspace ghcr.io/orangekame3/qasmfmt:latest /workspace/example.qasm
+
+# Format in-place
+docker run --rm -v $(pwd):/workspace ghcr.io/orangekame3/qasmfmt:latest -w /workspace/example.qasm
+```
+
 ## Usage
 
 ### Basic Usage
@@ -89,6 +102,53 @@ qasmfmt completion bash > /usr/local/etc/bash_completion.d/qasmfmt
 
 # Show version
 qasmfmt version
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+To integrate qasmfmt into your CI pipeline:
+
+#### Using the binary
+
+```yaml
+name: QASM Format Check
+
+on: [push, pull_request]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install qasmfmt
+        run: |
+          curl -L https://github.com/orangekame3/qasmfmt/releases/latest/download/qasmfmt_Linux_x86_64.tar.gz | tar -xz
+          sudo mv qasmfmt /usr/local/bin/
+      
+      - name: Check QASM formatting
+        run: qasmfmt -c *.qasm
+```
+
+#### Using Docker
+
+```yaml
+name: QASM Format Check
+
+on: [push, pull_request]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check QASM formatting
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace \
+            ghcr.io/orangekame3/qasmfmt:latest -c /workspace/*.qasm
 ```
 
 ## Example
@@ -195,7 +255,7 @@ Contributions are welcome! Please see [DEVELOPMENT.md](DEVELOPMENT.md) for devel
 
 ## License
 
-[MIT License](LICENSE)
+[Apache License 2.0](LICENSE)
 
 ## Related Projects
 


### PR DESCRIPTION
Introduce a GitHub Actions workflow for building and pushing Docker images, along with examples for CI integration. Update the project license from MIT to Apache 2.0.