### PR TITLE
Release for v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.9](https://github.com/orangekame3/qasmfmt/compare/v0.0.8...v0.0.9) - 2025-06-28
+- Fix code block syntax in README.md by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/29
+- Add support for barrier and reset statements in formatter by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/31
+
 ## [v0.0.8](https://github.com/orangekame3/qasmfmt/compare/v0.0.7...v0.0.8) - 2025-06-28
 - Add logo to qasmfmt documentation by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/27
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "0.0.8"
+	Version   = "0.0.9"
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )


### PR DESCRIPTION
This pull request is for the next release as v0.0.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix code block syntax in README.md by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/29
* Add support for barrier and reset statements in formatter by @orangekame3 in https://github.com/orangekame3/qasmfmt/pull/31


**Full Changelog**: https://github.com/orangekame3/qasmfmt/compare/v0.0.8...v0.0.9