### PR TITLE
Add support for barrier and reset statements in formatter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,186 @@
+# qasmfmt TODO - OpenQASM 3.0 Feature Support
+
+Based on analysis of the [OpenQASM 3.0 specification](https://github.com/openqasm/openqasm), this document outlines missing features and improvements needed for comprehensive OpenQASM support.
+
+## Current Status
+qasmfmt supports basic OpenQASM 3.0 formatting and has been extended with several additional features. See [README.md](README.md#supported-openqasm-30-features) for current capabilities.
+
+### ✅ Recently Completed Features
+- **Barrier statements**: `barrier;`, `barrier q;`, `barrier q[0], q[1];`
+- **Reset statements**: `reset q;`, `reset q[0];`
+- **Parameterized gates**: `rz(pi/4) q[0];`, `cphase(pi/2) q[0], q[1];`
+- **Comment preservation infrastructure**: Framework added (limited by lexer)
+
+## 🚀 High Priority Features
+
+### Advanced Gate Definitions
+- [ ] **Custom gate definitions with parameters**
+  - Currently: Basic gate definition support (placeholders)
+  - Needed: Full gate body formatting, parameter handling
+  - Example: `gate rz(theta) q { U(0, 0, theta) q; }`
+
+### Function and Subroutine Support
+- [ ] **Function definitions and calls**
+  - Currently: Not supported
+  - Needed: `def` function formatting, parameter lists, return types
+  - Example: `def majority(qubit a, qubit b, qubit c) { /* body */ }`
+
+- [ ] **Subroutine definitions**
+  - Currently: Not supported  
+  - Needed: Classical subroutines with proper formatting
+
+### Control Flow Statements
+- [ ] **If/else statements**
+  - Currently: Basic support (placeholder formatting)
+  - Needed: Proper conditional formatting, nested blocks
+
+- [ ] **For loops**
+  - Currently: Not supported
+  - Needed: Loop formatting with proper indentation
+
+- [ ] **While loops**
+  - Currently: Not supported
+  - Needed: While loop formatting and condition handling
+
+### Advanced Data Types and Arrays
+- [ ] **Multi-dimensional arrays**
+  - Currently: Not supported
+  - Needed: Array declaration formatting: `array[int[8], 16] my_ints;`
+
+- [ ] **Array operations and indexing**
+  - Currently: Not supported
+  - Needed: Slice notation: `my_array[0:1]`, multi-index access
+
+- [ ] **Complex types (int, uint, float with bit widths)**
+  - Currently: Basic bit/qubit only
+  - Needed: `int[32]`, `uint[16]`, `float[64]` formatting
+
+## 🔧 Medium Priority Features
+
+### Calibration and Timing
+- [ ] **defcal statements**
+  - Currently: Not supported
+  - Needed: Calibration definition formatting
+  - Example: `defcal x $0 { play drive($0), gaussian(...); }`
+
+- [ ] **Timing constructs**
+  - Currently: Not supported
+  - Needed: `delay`, `durationof`, timing expressions
+
+- [ ] **Pulse definitions**
+  - Currently: Not supported
+  - Needed: `play`, `capture`, `shift_phase` formatting
+
+### Advanced Gate Operations
+- [x] **Parameterized gates**
+  - ✅ **COMPLETED**: Gates with expressions: `rz(pi/4)`, `cphase(theta)`
+  - Supports single and multi-qubit parameterized gates with proper spacing
+
+- [ ] **Gate modifiers**
+  - Currently: Not supported
+  - Needed: `ctrl @`, `inv @`, `pow(n) @` formatting
+
+- [x] **Barrier statements**
+  - ✅ **COMPLETED**: `barrier;`, `barrier q;`, `barrier q[0], q[1];` formatting
+
+### Classical Computation
+- [ ] **Classical expressions and operations**
+  - Currently: Basic assignment support
+  - Needed: Complex arithmetic, function calls
+
+- [ ] **Constant definitions**
+  - Currently: Not supported
+  - Needed: `const` declarations
+
+- [ ] **Type casting and conversions**
+  - Currently: Not supported
+  - Needed: Type conversion formatting
+
+## 🎯 Low Priority Features
+
+### Reset and Initialization
+- [x] **Reset statements**  
+  - ✅ **COMPLETED**: `reset q;`, `reset q[0];` formatting
+  - Supports proper spacing and qubit indexing
+
+### Advanced Language Constructs
+- [ ] **extern function declarations**
+  - Currently: Not supported
+  - Needed: External function interface formatting
+
+- [ ] **pragma statements**  
+  - Currently: Not supported
+  - Needed: Compiler directive formatting
+
+- [ ] **switch/case statements**
+  - Currently: Not supported
+  - Needed: Switch statement formatting
+
+### Enhanced Comment Support
+- [x] **Comment preservation and positioning**
+  - ⚠️ **PARTIALLY COMPLETED**: Infrastructure added, limited by lexer grammar
+  - Current limitation: Comments are skipped in lexer, requires grammar modification
+
+- [ ] **Multi-line comment formatting**
+  - Currently: Limited support
+  - Needed: `/* */` block comment formatting
+
+### Error Handling and Diagnostics
+- [ ] **Better error messages**
+  - Currently: Basic parse errors
+  - Needed: Detailed syntax error reporting with line numbers
+
+- [ ] **Syntax recovery**
+  - Currently: Basic malformed code repair
+  - Needed: More sophisticated error recovery
+
+## 🔄 Code Quality Improvements
+
+### Parser and Formatter Enhancements
+- [ ] **Update ANTLR grammar to latest OpenQASM spec**
+  - Current: Basic OpenQASM 3.0 support
+  - Needed: Full spec compliance, latest language features
+
+- [ ] **Improved formatting rules**
+  - Current: Basic spacing and indentation
+  - Needed: More sophisticated layout, alignment options
+
+- [ ] **Configuration system**
+  - Current: Basic indent/newline config
+  - Needed: Comprehensive formatting preferences
+
+### Testing and Validation
+- [ ] **Extended test suite**
+  - Current: Basic formatting tests
+  - Needed: Tests for all OpenQASM features
+
+- [ ] **Compliance testing against reference implementations**
+  - Current: None
+  - Needed: Validation against Qiskit, other OpenQASM parsers
+
+- [ ] **Performance optimization**
+  - Current: Adequate for small files
+  - Needed: Optimization for large quantum circuits
+
+## 📚 Legacy TODO Items
+
+### Formatting Quality & Readability
+- [ ] **Introduction of Semantic Formatting Rules:**
+  - Implement rules for aligning multi-line statements (e.g., declarations, assignments) to improve vertical readability
+  - Develop intelligent line-breaking strategies for long expressions, function calls, and complex statements to enhance code clarity
+  - Consider rules for consistent spacing around operators, keywords, and punctuation
+
+### Usability & Configuration  
+- [ ] **Expanded Configuration Options:**
+  - Allow users to specify OpenQASM version targets for formatting, enabling compatibility with different specification versions
+  - Introduce configurable formatting styles (e.g., indentation size, brace style, maximum line length) to align with various coding standards and personal preferences
+  - Provide options to enable/disable specific formatting rules
+
+- [ ] **Integration with Build Systems and IDEs:**
+  - VS Code extension for qasmfmt
+  - Pre-commit hook templates
+  - Better integration with quantum development tools
+
+## References
+- [OpenQASM 3.0 Specification](https://github.com/openqasm/openqasm)
+- [OpenQASM Examples](https://github.com/openqasm/openqasm/tree/main/examples)

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -564,7 +564,7 @@ func (f *Formatter) formatProgramWithComments(program *parser.ProgramContext, co
 	}
 
 	currentLine := 2 // Start from line 2 after version
-	
+
 	for _, stmtOrScope := range program.AllStatementOrScope() {
 		if stmtOrScope == nil {
 			continue
@@ -620,12 +620,12 @@ func (f *Formatter) formatProgramWithComments(program *parser.ProgramContext, co
 func (f *Formatter) formatBarrier(ctx parser.IBarrierStatementContext, indent int) string {
 	text := ctx.GetText()
 	text = strings.TrimSuffix(text, ";")
-	
+
 	// Handle "barrier" or "barrier q" or "barrier q[0], q[1]"
 	if strings.TrimSpace(text) == "barrier" {
 		return f.indent(indent) + "barrier;"
 	}
-	
+
 	// Format with operands
 	formatted := f.formatBarrierText(text)
 	return f.indent(indent) + formatted + ";"

--- a/cmd/formatter.go
+++ b/cmd/formatter.go
@@ -130,6 +130,12 @@ func (f *Formatter) getStatementType(stmtOrScope parser.IStatementOrScopeContext
 		if stmt.GateStatement() != nil {
 			return "gate_definition"
 		}
+		if stmt.BarrierStatement() != nil {
+			return "barrier"
+		}
+		if stmt.ResetStatement() != nil {
+			return "reset"
+		}
 		if strings.HasPrefix(stmt.GetText(), "include") {
 			return "include"
 		}
@@ -211,6 +217,14 @@ func (f *Formatter) formatStatement(stmt parser.IStatementContext, indent int) s
 
 	if ifStmt := stmt.IfStatement(); ifStmt != nil {
 		return f.formatIf(ifStmt, indent)
+	}
+
+	if barrierStmt := stmt.BarrierStatement(); barrierStmt != nil {
+		return f.formatBarrier(barrierStmt, indent)
+	}
+
+	if resetStmt := stmt.ResetStatement(); resetStmt != nil {
+		return f.formatReset(resetStmt, indent)
 	}
 
 	text := strings.TrimSpace(stmt.GetText())
@@ -310,28 +324,41 @@ func (f *Formatter) formatDeclarationText(text string) string {
 
 func (f *Formatter) formatGateCallText(text string) string {
 	// Handle gate calls like "hq", "hq[0]" -> "h q", "h q[0]" and "cxq[0],q[1]" -> "cx q[0], q[1]"
+	// Also handle parameterized gates like "rz(pi/4)q[0]" -> "rz(pi/4) q[0]"
 
-	// Case 1: Simple gate with identifier (hq -> h q)
-	re1 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*)$`)
+	// Case 1: Parameterized gate with qubit (rz(pi/4)q[0] -> rz(pi/4) q[0])
+	re1 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)\(([^)]+)\)([a-zA-Z_][a-zA-Z0-9_]*(?:\[[^\]]+\])?)$`)
 	if re1.MatchString(text) {
-		return re1.ReplaceAllString(text, "$1 $2")
+		return re1.ReplaceAllString(text, "$1($2) $3")
 	}
 
-	// Case 2: Gate with indexed qubit (hq[0] -> h q[0])
-	re2 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\])$`)
+	// Case 2: Parameterized gate with multiple qubits (cphase(pi/2)q[0],q[1] -> cphase(pi/2) q[0], q[1])
+	re2 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)\(([^)]+)\)([a-zA-Z_][a-zA-Z0-9_]*(?:\[[^\]]+\])?),([a-zA-Z_][a-zA-Z0-9_]*(?:\[[^\]]+\])?)$`)
 	if re2.MatchString(text) {
-		return re2.ReplaceAllString(text, "$1 $2")
+		return re2.ReplaceAllString(text, "$1($2) $3, $4")
 	}
 
-	// Case 3: Two-qubit gate (cxq[0],q[1] -> cx q[0], q[1])
-	re3 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\]),([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\])$`)
+	// Case 3: Simple gate with identifier (hq -> h q)
+	re3 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*)$`)
 	if re3.MatchString(text) {
-		return re3.ReplaceAllString(text, "$1 $2, $3")
+		return re3.ReplaceAllString(text, "$1 $2")
+	}
+
+	// Case 4: Gate with indexed qubit (hq[0] -> h q[0])
+	re4 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\])$`)
+	if re4.MatchString(text) {
+		return re4.ReplaceAllString(text, "$1 $2")
+	}
+
+	// Case 5: Two-qubit gate (cxq[0],q[1] -> cx q[0], q[1])
+	re5 := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\]),([a-zA-Z_][a-zA-Z0-9_]*\[[^\]]+\])$`)
+	if re5.MatchString(text) {
+		return re5.ReplaceAllString(text, "$1 $2, $3")
 	}
 
 	// Handle comma-separated qubits for already well-formed cases
-	re4 := regexp.MustCompile(`,\s*`)
-	result := re4.ReplaceAllString(text, ", ")
+	re6 := regexp.MustCompile(`,\s*`)
+	result := re6.ReplaceAllString(text, ", ")
 
 	return result
 }
@@ -515,20 +542,127 @@ func (f *Formatter) extractComments(tokenStream *antlr.CommonTokenStream) []Comm
 
 // formatProgramWithComments formats the program while preserving comments
 func (f *Formatter) formatProgramWithComments(program *parser.ProgramContext, comments []Comment) string {
-	// For now, fall back to the regular formatter and append comments at the end
-	// This is a simplified implementation - a more sophisticated one would
-	// position comments correctly relative to statements
+	// Improved comment preservation - try to associate comments with their statements
+	if len(comments) == 0 {
+		return f.formatProgram(program)
+	}
 
-	result := f.formatProgram(program)
+	var lines []string
+	var lastStatementType string
+	commentIndex := 0
 
-	// Add comments at the end for now
-	if len(comments) > 0 {
-		result = strings.TrimSuffix(result, "\n")
-		for _, comment := range comments {
-			result += "\n" + comment.Text
+	// Handle version
+	if program.Version() != nil {
+		versionLine := "OPENQASM 3.0;"
+		// Check if there's a comment on the same line
+		if commentIndex < len(comments) && comments[commentIndex].Line == 1 {
+			versionLine += " " + comments[commentIndex].Text
+			commentIndex++
 		}
+		lines = append(lines, versionLine)
+		lastStatementType = "version"
+	}
+
+	currentLine := 2 // Start from line 2 after version
+	
+	for _, stmtOrScope := range program.AllStatementOrScope() {
+		if stmtOrScope == nil {
+			continue
+		}
+
+		// Add standalone comments before this statement
+		for commentIndex < len(comments) && comments[commentIndex].Line < currentLine {
+			comment := comments[commentIndex]
+			if f.shouldAddEmptyLine(lastStatementType, "comment") {
+				lines = append(lines, "")
+			}
+			lines = append(lines, comment.Text)
+			commentIndex++
+			lastStatementType = "comment"
+		}
+
+		formatted := f.formatStatementOrScope(stmtOrScope, 0)
+		if strings.TrimSpace(formatted) != "" && !strings.HasSuffix(formatted, ";;") {
+			currentType := f.getStatementType(stmtOrScope)
+
+			// Add empty line between different types of statements
+			if f.shouldAddEmptyLine(lastStatementType, currentType) {
+				lines = append(lines, "")
+			}
+
+			// Check if there's a comment on the same line as this statement
+			if commentIndex < len(comments) && comments[commentIndex].Line == currentLine {
+				formatted += " " + comments[commentIndex].Text
+				commentIndex++
+			}
+
+			lines = append(lines, formatted)
+			lastStatementType = currentType
+		}
+		currentLine++
+	}
+
+	// Add any remaining comments at the end
+	for commentIndex < len(comments) {
+		comment := comments[commentIndex]
+		lines = append(lines, comment.Text)
+		commentIndex++
+	}
+
+	result := strings.Join(lines, "\n")
+	if f.newline && !strings.HasSuffix(result, "\n") {
 		result += "\n"
 	}
 
 	return result
+}
+
+func (f *Formatter) formatBarrier(ctx parser.IBarrierStatementContext, indent int) string {
+	text := ctx.GetText()
+	text = strings.TrimSuffix(text, ";")
+	
+	// Handle "barrier" or "barrier q" or "barrier q[0], q[1]"
+	if strings.TrimSpace(text) == "barrier" {
+		return f.indent(indent) + "barrier;"
+	}
+	
+	// Format with operands
+	formatted := f.formatBarrierText(text)
+	return f.indent(indent) + formatted + ";"
+}
+
+func (f *Formatter) formatReset(ctx parser.IResetStatementContext, indent int) string {
+	text := ctx.GetText()
+	text = strings.TrimSuffix(text, ";")
+	formatted := f.formatResetText(text)
+	return f.indent(indent) + formatted + ";"
+}
+
+func (f *Formatter) formatBarrierText(text string) string {
+	// Handle "barrierq" -> "barrier q" and "barrierq[0],q[1]" -> "barrier q[0], q[1]"
+	re := regexp.MustCompile(`^barrier\s*(.+)$`)
+	if re.MatchString(text) {
+		matches := re.FindStringSubmatch(text)
+		if len(matches) > 1 {
+			operands := strings.TrimSpace(matches[1])
+			// Format comma-separated operands
+			re2 := regexp.MustCompile(`,\s*`)
+			operands = re2.ReplaceAllString(operands, ", ")
+			return "barrier " + operands
+		}
+	}
+	return text
+}
+
+func (f *Formatter) formatResetText(text string) string {
+	// Handle "resetq" -> "reset q" and "resetq[0]" -> "reset q[0]"
+	re := regexp.MustCompile(`^reset\s*(.+)$`)
+	if re.MatchString(text) {
+		matches := re.FindStringSubmatch(text)
+		if len(matches) > 1 {
+			operand := strings.TrimSpace(matches[1])
+			return "reset " + operand
+		}
+	}
+	return text
 }


### PR DESCRIPTION
Enhance the formatter to support barrier and reset statements, improving compliance with OpenQASM 3.0 specifications.